### PR TITLE
performance_optimization_emeka

### DIFF
--- a/api/nigeriaemr-api.iml
+++ b/api/nigeriaemr-api.iml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="Spring" name="Spring">
+      <configuration>
+        <fileset id="fileset" name="Spring Application Context" removed="false">
+          <file>file://$MODULE_DIR$/src/main/resources/moduleApplicationContext.xml</file>
+        </fileset>
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.module:htmlformentry-api:3.4.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: joda-time:joda-time:2.9.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.joda:joda-convert:1.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.anotheria:ano-web:2.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.module:htmlformentryui-api:1.6.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.module:uiframework-api:3.13.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.github.jknack:handlebars:1.3.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.antlr:antlr4-runtime:4.2.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.antlr:antlr4-annotations:4.2.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.mozilla:rhino:1.7R4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.owasp.encoder:encoder:1.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.module:formentryapp-omod:1.4.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.module:formentryapp-api:1.4.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.module:appframework-api:2.10.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.api:openmrs-api:1.11.6" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-collections:commons-collections:3.2.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.commons:commons-lang3:3.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-beanutils:commons-beanutils:1.7.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-io:commons-io:1.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.azeckoski:reflectutils:0.9.14" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.velocity:velocity:1.6.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-lang:commons-lang:2.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: log4j:log4j:1.2.15" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-core:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-beans:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-context:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-expression:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-aop:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: aopalliance:aopalliance:1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-orm:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-tx:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-jdbc:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.antlr:antlr-runtime:3.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.antlr:stringtemplate:3.2.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: antlr:antlr:2.7.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: asm:asm-commons:2.2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: asm:asm-tree:2.2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: asm:asm:2.2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: asm:asm-util:2.2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: cglib:cglib-nodep:2.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: ca.uhn.hapi:hapi-base:2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-cli:commons-cli:1.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.jdom:jdom:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xalan:xalan:2.7.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: ca.uhn.hapi:hapi-structures-v25:2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: ca.uhn.hapi:hapi-structures-v26:2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.simpleframework:simple-xml:1.6.1-mod" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: stax:stax:1.2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: stax:stax-api:1.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.javassist:javassist:3.19.0-GA" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.hibernate:hibernate-core:3.6.5.Final-mod" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-commons-annotations:3.2.0.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate.javax.persistence:hibernate-jpa-2.0-api:1.0.0.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.transaction:jta:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-c3p0:3.6.5.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-ehcache:3.6.5.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-search:3.4.2.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-search-analyzers:3.4.2.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-analyzers:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.solr:solr-analysis-extras:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.solr:solr-core:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.solr:solr-solrj:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-highlighter:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-memory:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-misc:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-spatial:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-spellchecker:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.solr:solr-commons-csv:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-codec:commons-codec:1.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-smartcn:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-stempel:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-core:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-queries:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: jakarta-regexp:jakarta-regexp:1.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: dom4j:dom4j:1.6.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: c3p0:c3p0:0.9.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.sf.ehcache:ehcache-core:2.2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:slf4j-api:1.6.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:jcl-over-slf4j:1.6.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:slf4j-log4j12:1.6.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.thoughtworks.xstream:xstream:1.4.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xmlpull:xmlpull:1.1.3.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xpp3:xpp3_min:1.1.4c" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.mail:mail:1.4.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.activation:activation:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.liquibase:liquibase-core:2.0.5" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.liquibase.ext:modify-column:2.0.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.liquibase.ext:identity-insert:1.2.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.liquibase.ext:type-converter:1.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xerces:xercesImpl:2.8.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xml-apis:xml-apis:1.3.03" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xml-resolver:xml-resolver:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.validation:validation-api:1.0.0.GA" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-validator:4.2.0.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.jackson:jackson-core-asl:1.9.13" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.jackson:jackson-mapper-asl:1.9.13" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.groovy:groovy-all:1.7.6" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.openmrs.api:openmrs-api:tests:1.11.6" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.springframework:spring-test:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.h2database:h2:1.4.187" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.databene:databene-benerator:0.5.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.databene:databene-webdecs:0.4.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.poi:poi:3.5-beta5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.freemarker:freemarker:2.3.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.databene:databene-commons:0.4.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.databene:databene-gui:0.1.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.sourceforge.jtds:jtds:1.2.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: mysql:mysql-connector-java:5.1.6" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.derby:derbyclient:10.4.2.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: postgresql:postgresql:8.3-603.jdbc4" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.dbunit:dbunit:2.4.7" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: xmlunit:xmlunit:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.carrotsearch:junit-benchmarks:0.7.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.11" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-library:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:1.9.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-module-junit4:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-module-junit4-common:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-core:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-reflect:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-api-mockito:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-api-support:1.5" level="project" />
+  </component>
+</module>

--- a/nigeriaemr.iml
+++ b/nigeriaemr.iml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.api:openmrs-api:1.11.6" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-collections:commons-collections:3.2.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.commons:commons-lang3:3.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-beanutils:commons-beanutils:1.7.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-io:commons-io:1.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.azeckoski:reflectutils:0.9.14" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.velocity:velocity:1.6.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-lang:commons-lang:2.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: log4j:log4j:1.2.15" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-core:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-beans:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-context:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-expression:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-aop:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: aopalliance:aopalliance:1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-orm:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-tx:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-jdbc:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.antlr:antlr-runtime:3.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.antlr:stringtemplate:3.2.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: antlr:antlr:2.7.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: asm:asm-commons:2.2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: asm:asm-tree:2.2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: asm:asm:2.2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: asm:asm-util:2.2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: cglib:cglib-nodep:2.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: ca.uhn.hapi:hapi-base:2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-cli:commons-cli:1.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.jdom:jdom:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xalan:xalan:2.7.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: ca.uhn.hapi:hapi-structures-v25:2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: ca.uhn.hapi:hapi-structures-v26:2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.simpleframework:simple-xml:1.6.1-mod" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: stax:stax:1.2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: stax:stax-api:1.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.javassist:javassist:3.19.0-GA" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.hibernate:hibernate-core:3.6.5.Final-mod" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-commons-annotations:3.2.0.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate.javax.persistence:hibernate-jpa-2.0-api:1.0.0.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.transaction:jta:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-c3p0:3.6.5.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-ehcache:3.6.5.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-search:3.4.2.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-search-analyzers:3.4.2.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-analyzers:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.solr:solr-analysis-extras:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.solr:solr-core:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.solr:solr-solrj:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-highlighter:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-memory:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-misc:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-spatial:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-spellchecker:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.solr:solr-commons-csv:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-codec:commons-codec:1.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-smartcn:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-stempel:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-core:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-queries:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: jakarta-regexp:jakarta-regexp:1.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: dom4j:dom4j:1.6.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: c3p0:c3p0:0.9.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.sf.ehcache:ehcache-core:2.2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:slf4j-api:1.6.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:jcl-over-slf4j:1.6.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:slf4j-log4j12:1.6.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.thoughtworks.xstream:xstream:1.4.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xmlpull:xmlpull:1.1.3.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xpp3:xpp3_min:1.1.4c" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.mail:mail:1.4.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.activation:activation:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.liquibase:liquibase-core:2.0.5" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.liquibase.ext:modify-column:2.0.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.liquibase.ext:identity-insert:1.2.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.liquibase.ext:type-converter:1.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xerces:xercesImpl:2.8.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xml-apis:xml-apis:1.3.03" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xml-resolver:xml-resolver:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.validation:validation-api:1.0.0.GA" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-validator:4.2.0.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.jackson:jackson-core-asl:1.9.13" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.jackson:jackson-mapper-asl:1.9.13" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.groovy:groovy-all:1.7.6" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.openmrs.api:openmrs-api:tests:1.11.6" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.springframework:spring-test:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.h2database:h2:1.4.187" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.databene:databene-benerator:0.5.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.databene:databene-webdecs:0.4.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.poi:poi:3.5-beta5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.freemarker:freemarker:2.3.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.databene:databene-commons:0.4.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.databene:databene-gui:0.1.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.sourceforge.jtds:jtds:1.2.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: mysql:mysql-connector-java:5.1.6" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.derby:derbyclient:10.4.2.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: postgresql:postgresql:8.3-603.jdbc4" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.dbunit:dbunit:2.4.7" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: xmlunit:xmlunit:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.carrotsearch:junit-benchmarks:0.7.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.11" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-library:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:1.9.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-module-junit4:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-module-junit4-common:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-core:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-reflect:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-api-mockito:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-api-support:1.5" level="project" />
+  </component>
+</module>

--- a/omod/nigeriaemr-omod.iml
+++ b/omod/nigeriaemr-omod.iml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="Spring" name="Spring">
+      <configuration>
+        <fileset id="fileset" name="Spring Application Context" removed="false">
+          <file>file://$MODULE_DIR$/src/main/resources/webModuleApplicationContext.xml</file>
+        </fileset>
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/webapp" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="nigeriaemr-api" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.web:openmrs-web:1.11.6" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.servlet:servlet-api:2.5" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.servlet:jsp-api:2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.servlet:jstl:1.1.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.directwebremoting:dwr:2.0.5-mod" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-beanutils:commons-beanutils:1.7.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-io:commons-io:1.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-fileupload:commons-fileupload:1.2.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.sf.saxon:saxon:8.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.sf.saxon:saxon-dom:8.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-web:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-webmvc:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-expression:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-oxm:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: jfree:jfreechart:1.0.12" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: jfree:jcommon:1.0.15" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: mysql:mysql-connector-java:5.1.28" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: postgresql:postgresql:9.0-801.jdbc4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.sourceforge.jtds:jtds:1.2.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: taglibs:request:1.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: taglibs:response:1.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: taglibs:standard:1.1.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: taglibs:page:1.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.liquibase:liquibase-core:2.0.5" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:jcl-over-slf4j:1.6.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.velocity:velocity-tools:2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-digester:commons-digester:1.8" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-chain:commons-chain:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-validator:commons-validator:1.3.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: oro:oro:2.0.8" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: sslext:sslext:1.2-0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.struts:struts-core:1.3.8" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.struts:struts-taglib:1.3.8" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.struts:struts-tiles:1.3.8" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.web:openmrs-web:tests:1.11.6" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.module:uiframework-api:3.13.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.github.jknack:handlebars:1.3.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.antlr:antlr4-runtime:4.2.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.antlr:antlr4-annotations:4.2.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.mozilla:rhino:1.7R4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.owasp.encoder:encoder:1.2" level="project" />
+    <orderEntry type="library" name="Maven: joda-time:joda-time:1.6" level="project" />
+    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.5" level="project" />
+    <orderEntry type="library" name="Maven: org.json:json:20160212" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.8.0" level="project" />
+    <orderEntry type="library" name="Maven: com.mashape.unirest:unirest-java:1.4.9" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.5.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.4" level="project" />
+    <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpasyncclient:4.1.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore-nio:4.4.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpmime:4.5.2" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.9.4" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.9.0" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.9.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.module:htmlformentry-api:3.4.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.joda:joda-convert:1.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.anotheria:ano-web:2.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.module:htmlformentryui-api:1.6.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.api:openmrs-api:1.11.6" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-collections:commons-collections:3.2.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.commons:commons-lang3:3.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.azeckoski:reflectutils:0.9.14" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.velocity:velocity:1.6.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-lang:commons-lang:2.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: log4j:log4j:1.2.15" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-core:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-beans:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-context:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-aop:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: aopalliance:aopalliance:1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-orm:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-tx:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-jdbc:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.antlr:antlr-runtime:3.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.antlr:stringtemplate:3.2.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: antlr:antlr:2.7.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: asm:asm-commons:2.2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: asm:asm-tree:2.2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: asm:asm:2.2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: asm:asm-util:2.2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: cglib:cglib-nodep:2.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: ca.uhn.hapi:hapi-base:2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-cli:commons-cli:1.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.jdom:jdom:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xalan:xalan:2.7.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: ca.uhn.hapi:hapi-structures-v25:2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: ca.uhn.hapi:hapi-structures-v26:2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.simpleframework:simple-xml:1.6.1-mod" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: stax:stax:1.2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: stax:stax-api:1.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.javassist:javassist:3.19.0-GA" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.hibernate:hibernate-core:3.6.5.Final-mod" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-commons-annotations:3.2.0.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate.javax.persistence:hibernate-jpa-2.0-api:1.0.0.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.transaction:jta:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-c3p0:3.6.5.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-ehcache:3.6.5.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-search:3.4.2.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-search-analyzers:3.4.2.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-analyzers:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.solr:solr-analysis-extras:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.solr:solr-core:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.solr:solr-solrj:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-highlighter:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-memory:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-misc:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-spatial:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-spellchecker:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.solr:solr-commons-csv:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-smartcn:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-stempel:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-core:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-queries:3.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: jakarta-regexp:jakarta-regexp:1.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: dom4j:dom4j:1.6.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: c3p0:c3p0:0.9.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.sf.ehcache:ehcache-core:2.2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:slf4j-api:1.6.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:slf4j-log4j12:1.6.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.thoughtworks.xstream:xstream:1.4.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xmlpull:xmlpull:1.1.3.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xpp3:xpp3_min:1.1.4c" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.mail:mail:1.4.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.activation:activation:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.liquibase.ext:modify-column:2.0.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.liquibase.ext:identity-insert:1.2.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.openmrs.liquibase.ext:type-converter:1.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xerces:xercesImpl:2.8.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xml-apis:xml-apis:1.3.03" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xml-resolver:xml-resolver:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.validation:validation-api:1.0.0.GA" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.hibernate:hibernate-validator:4.2.0.Final" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.jackson:jackson-core-asl:1.9.13" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.jackson:jackson-mapper-asl:1.9.13" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.groovy:groovy-all:1.7.6" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.openmrs.api:openmrs-api:tests:1.11.6" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.springframework:spring-test:3.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.h2database:h2:1.4.187" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.databene:databene-benerator:0.5.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.databene:databene-webdecs:0.4.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.poi:poi:3.5-beta5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.freemarker:freemarker:2.3.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.databene:databene-commons:0.4.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.databene:databene-gui:0.1.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.derby:derbyclient:10.4.2.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.dbunit:dbunit:2.4.7" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: xmlunit:xmlunit:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.carrotsearch:junit-benchmarks:0.7.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.11" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-library:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:1.9.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-module-junit4:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-module-junit4-common:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-core:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-reflect:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-api-mockito:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.powermock:powermock-api-support:1.5" level="project" />
+  </component>
+</module>

--- a/omod/src/main/java/org/openmrs/module/nigeriaemr/fragment/controller/NdrFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/nigeriaemr/fragment/controller/NdrFragmentController.java
@@ -35,26 +35,9 @@ public class NdrFragmentController {
 		
 	}
 	
-	public String generateNDRFile(HttpServletRequest request) throws DatatypeConfigurationException, IOException,
-	        SAXException, JAXBException, Throwable {
-		
-		//   FacilityLocationService facilityLocationService = new FacilityLocationService();
-		// Integer locationId = 8;
+	public String generateNDRFile(HttpServletRequest request) throws Throwable {
 		
 		DBConnection openmrsConn = Utils.getNmrsConnectionDetails();
-		
-		//		List<FacilityLocation> allFacilityLocations = facilityLocationService.getAllFacilityLocations();
-		//                List<PatientLocation> allPatientLocations = facilityLocationService.getAllPatientLocation();
-		//                
-		//                
-		//                FacilityLocation facilityLocation = allFacilityLocations.stream()
-		//                        .filter(a -> a.getLocation_id().equals(locationId)).findFirst().get();
-		//                List<Integer> filteredPatientByLocation = allPatientLocations.stream()
-		//                        .filter(a -> a.getLocation_id().equals(locationId))
-		//                        .map(PatientLocation::getPatient_id).collect(Collectors.toList());
-		//                
-		
-		//check i fglobal variable for logging exists
 		LoggerUtils.checkLoggerGlobalProperty(openmrsConn);
 		
 		//create report download folder at the server. skip if already exist

--- a/omod/src/main/java/org/openmrs/module/nigeriaemr/ndrUtils/LoggerUtils.java
+++ b/omod/src/main/java/org/openmrs/module/nigeriaemr/ndrUtils/LoggerUtils.java
@@ -162,11 +162,8 @@ public class LoggerUtils {
 				pStatement.setString(2, DEFAULT_LOGGER_GLOBAL_PROP_VALUE);
 				pStatement.setString(3, DEFAULT_LOGGER_GLOBAL_PROP_DESCRIPTION);
 				pStatement.setString(4, UUID.randomUUID().toString());
-				
 				pStatement.executeUpdate();
-				
 			}
-			
 		}
 		catch (SQLException ex) {
 			LoggerUtils.write(LoggerUtils.class.getName(), ex.getMessage(), LogFormat.FATAL, LogLevel.live);
@@ -179,13 +176,9 @@ public class LoggerUtils {
 				if (pStatement != null) {
 					pStatement.close();
 				}
-				
 			}
-			catch (SQLException ex) {
-				
-			}
+			catch (SQLException ex) {}
 		}
-		
 	}
 	
 	public static String getCurrentInstanceLogLevel() {

--- a/omod/src/main/java/org/openmrs/module/nigeriaemr/ndrfactory/ClinicalDictionary.java
+++ b/omod/src/main/java/org/openmrs/module/nigeriaemr/ndrfactory/ClinicalDictionary.java
@@ -386,7 +386,7 @@ public class ClinicalDictionary {
                 }
                 obs = Utils.extractObs(Utils.CD4_COUNT_CONCEPT, obsListForOneVisit);
 
-                if (obs != null && obs.getValueNumeric() != null) {
+                if (obs != null && obs.getValueNumeric() != null && obs.getValueNumeric().intValue() !=0) {
                     int  cd4Count = obs.getValueNumeric().intValue();
                     hivEncounterType.setCD4(cd4Count);
                     hivEncounterType.setCD4TestDate(Utils.getXmlDate(obs.getObsDatetime()));
@@ -420,7 +420,6 @@ public class ClinicalDictionary {
             int diff = period.getMonths();
             hivEncounter.setDurationOnArt(diff);
         }
-
         int conceptID;
         int value_numeric;
         int value_coded;

--- a/omod/src/main/java/org/openmrs/module/nigeriaemr/ndrfactory/ClinicalDictionary.java
+++ b/omod/src/main/java/org/openmrs/module/nigeriaemr/ndrfactory/ClinicalDictionary.java
@@ -282,8 +282,8 @@ public class ClinicalDictionary {
             obs = Utils.extractObs(Utils.FAMILY_PLANNING_STATUS_CONCEPT, obsListForOneVisit);
             //Does False Mean Not on Family Planninng
             if (obs != null && obs.getValueCoded() != null) {
-                valueBoolean = obs.getValueAsBoolean();
-                if (valueBoolean) {
+
+                if (obs.getValueCoded().getConceptId() == Utils.Yes_Concept_Id ) {
                     hivEncounterType.setPatientFamilyPlanningCode("FP");
                 } else {
                     hivEncounterType.setPatientFamilyPlanningCode("NOFP");

--- a/omod/src/main/java/org/openmrs/module/nigeriaemr/ndrfactory/LabDictionary.java
+++ b/omod/src/main/java/org/openmrs/module/nigeriaemr/ndrfactory/LabDictionary.java
@@ -199,8 +199,8 @@ public class LabDictionary {
 
         try {
 
-            PatientIdentifier pmtctIdentifier = pts.getPatientIdentifier(ConstantsUtil.PMTCT_IDENTIFIER_INDEX);
-            PatientIdentifier htsIdentifier = pts.getPatientIdentifier(ConstantsUtil.HTS_IDENTIFIER_INDEX);
+            //PatientIdentifier pmtctIdentifier = pts.getPatientIdentifier(ConstantsUtil.PMTCT_IDENTIFIER_INDEX);
+            //PatientIdentifier htsIdentifier = pts.getPatientIdentifier(ConstantsUtil.HTS_IDENTIFIER_INDEX);
 
             LaboratoryReportType labReportType = new LaboratoryReportType();
 
@@ -210,7 +210,7 @@ public class LabDictionary {
             labReportType.setCollectionDate(convertedDate);
 
            // Date artStartDate = Utils.extractARTStartDate(pts,labObsList);
-            if (artStartDate.after(enc.getEncounterDatetime()) || artStartDate.equals(enc.getEncounterDatetime())) {
+            if (artStartDate!=null && (artStartDate.after(enc.getEncounterDatetime()) || artStartDate.equals(enc.getEncounterDatetime()))) {
                 labReportType.setARTStatusCode("A");
             }else {
                 labReportType.setARTStatusCode("N");
@@ -260,7 +260,6 @@ public class LabDictionary {
             System.out.println(ex.getMessage());
             throw new DatatypeConfigurationException(Arrays.toString(ex.getStackTrace()));
         }
-
     }
 
     public List<LaboratoryReportType> createLaboratoryOrderAndResult(Patient pts, List<Encounter> allPatientEncounterList, List<Obs> allPatientObsList) {

--- a/omod/src/main/java/org/openmrs/module/nigeriaemr/ndrfactory/NDRMainDictionary.java
+++ b/omod/src/main/java/org/openmrs/module/nigeriaemr/ndrfactory/NDRMainDictionary.java
@@ -1,27 +1,16 @@
 package org.openmrs.module.nigeriaemr.ndrfactory;
 
-import com.mchange.v2.encounter.EncounterCounter;
 import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.Patient;
-import org.openmrs.PatientIdentifier;
 import org.openmrs.module.nigeriaemr.model.ndr.*;
 import org.openmrs.module.nigeriaemr.ndrUtils.LoggerUtils;
 import org.openmrs.module.nigeriaemr.ndrUtils.LoggerUtils.LogFormat;
 import org.openmrs.module.nigeriaemr.ndrUtils.Utils;
-import org.openmrs.util.OpenmrsUtil;
-
 import javax.xml.datatype.DatatypeConfigurationException;
-import java.io.*;
-import java.nio.file.Paths;
-import java.sql.*;
 import java.util.Date;
 import java.util.*;
-import org.apache.commons.codec.language.Soundex;
-import org.openmrs.module.nigeriaemr.ndrUtils.ConstantsUtil;
 import org.openmrs.module.nigeriaemr.ndrUtils.LoggerUtils.LogLevel;
-
-import static org.openmrs.module.nigeriaemr.ndrUtils.Utils.getXmlDate;
 import org.openmrs.module.nigeriaemr.omodmodels.DBConnection;
 
 //on master
@@ -56,12 +45,12 @@ public class NDRMainDictionary {
     private String appDirectory = "";
 
     private static Map<Integer, String> map = new HashMap<>();
-    private ClinicalDictionary clinicalDictionary = null;
-    private PMTCTDictionary pmtctDictionary = null;
-    private HTSDictionary htsDictionary = null;
-    private LabDictionary labDictionary = null;
-    private PharmacyDictionary pharmDictionary = null;
-    private NDRCommonQuestionsDictionary commonQuestionDictionary = null;
+    private ClinicalDictionary clinicalDictionary;
+    private PMTCTDictionary pmtctDictionary;
+    private HTSDictionary htsDictionary;
+    private LabDictionary labDictionary;
+    private PharmacyDictionary pharmDictionary;
+    private NDRCommonQuestionsDictionary commonQuestionDictionary;
 
     public NDRMainDictionary() {
         loadDictionary();
@@ -170,7 +159,6 @@ public class NDRMainDictionary {
         map.put(164948, "HIVPCR");
          */
         map.put(0, "");
-        map.put(0, "");
 
     }
 
@@ -189,9 +177,7 @@ public class NDRMainDictionary {
     }
 
     public CommonQuestionsType createCommonQuestionType2(Patient patient, List<Encounter> allPatientEncounterList, List<Obs> allPatientObsList) throws DatatypeConfigurationException {
-        CommonQuestionsType commonQuestionsType = null;
-        commonQuestionsType = commonQuestionDictionary.createCommonQuestionType(patient, allPatientEncounterList, allPatientObsList);
-        return commonQuestionsType;
+        return commonQuestionDictionary.createCommonQuestionType(patient, allPatientEncounterList, allPatientObsList);
     }
 
     public ConditionSpecificQuestionsType createCommConditionSpecificQuestionsType(Patient patient, List<Encounter> allPatientEncounterList, List<Obs> allPatientObsList) throws DatatypeConfigurationException {
@@ -203,7 +189,7 @@ public class NDRMainDictionary {
     }
 
     public List<RegimenType> createRegimenTypeList(Patient patient, List<Encounter> allEncounterForPatient, List<Obs> allPatientObsList) throws DatatypeConfigurationException {
-        List<RegimenType> allRegimenTypeList = new ArrayList<RegimenType>();
+        List<RegimenType> allRegimenTypeList = new ArrayList<>();
         allRegimenTypeList.addAll(pharmDictionary.createRegimenTypeList(patient, allEncounterForPatient, allPatientObsList));
         allRegimenTypeList.addAll(pharmDictionary.createOIRegimenTypeList(patient, allEncounterForPatient, allPatientObsList));
         return allRegimenTypeList;

--- a/omod/src/main/java/org/openmrs/module/nigeriaemr/ndrfactory/PharmacyDictionary.java
+++ b/omod/src/main/java/org/openmrs/module/nigeriaemr/ndrfactory/PharmacyDictionary.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.xml.datatype.DatatypeConfigurationException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
 import org.openmrs.Encounter;
 import org.openmrs.Obs;
@@ -270,10 +269,10 @@ public class PharmacyDictionary {
     }
 
     public List<RegimenType> createRegimenTypeList(Patient patient, List<Encounter> allEncounterForPatient,List<Obs> patientsObsList) throws DatatypeConfigurationException{
-        List<RegimenType> regimenTypeList=new ArrayList<RegimenType>();
+        List<RegimenType> regimenTypeList=new ArrayList<>();
         Integer[] targetEncounterTypes={Utils.CARE_CARD_ENCOUNTER_TYPE,Utils.PHARMACY_ENCOUNTER_TYPE};
-        RegimenType regimenType=null;
-        List<Obs> obsPerVisit=null;
+        RegimenType regimenType;
+        List<Obs> obsPerVisit;
         Set<Date> visitDateSet=Utils.extractUniqueVisitsForEncounterTypes(patient, allEncounterForPatient, targetEncounterTypes);
         for(Date visitDate: visitDateSet){
             obsPerVisit=Utils.extractObsPerVisitDate(visitDate, patientsObsList);
@@ -284,25 +283,18 @@ public class PharmacyDictionary {
     }
     
     public List<RegimenType> createOIRegimenTypeList(Patient patient, List<Encounter> allEncounterForPatient,List<Obs> patientsObsList) throws DatatypeConfigurationException{
-        List<RegimenType> regimenTypeList=new ArrayList<RegimenType>();
+        List<RegimenType> regimenTypeList=new ArrayList<>();
         Integer[] targetEncounterTypes={Utils.CARE_CARD_ENCOUNTER_TYPE,Utils.PHARMACY_ENCOUNTER_TYPE};
-        RegimenType regimenType=null;
-        List<Obs> obsPerVisit=null;
+        //RegimenType regimenType=null;
+        //List<Obs> obsPerVisit;
         for(Encounter enc: allEncounterForPatient){
             if(enc.getEncounterType().getEncounterTypeId()==Utils.PHARMACY_ENCOUNTER_TYPE){
-                obsPerVisit=new ArrayList<Obs>(enc.getAllObs());
+                //obsPerVisit=new ArrayList<Obs>(enc.getAllObs());
                 //regimenType=createOIType(patient, enc, obsPerVisit);
-                regimenTypeList.addAll(createOITypes(patient, enc, patientsObsList));
+                regimenTypeList.addAll(createOITypes(patient, enc, patientsObsList)); // ));
             }
         }
         return regimenTypeList;
-        //Set<Date> visitDateSet=Utils.extractUniqueVisitsForEncounterTypes(patient, allEncounterForPatient, targetEncounterTypes);
-        //for(Date visitDate: visitDateSet){
-            //obsPerVisit=Utils.extractObsPerVisitDate(visitDate, patientsObsList);
-            //regimenType=createRegimenType(patient, visitDate, obsPerVisit);
-            //regimenTypeList.add(regimenType);
-        //}
-        
     }
 
     /*
@@ -337,20 +329,17 @@ public class PharmacyDictionary {
   -ReasonRegimenEndedCode
   
          */
-        String visitID = "";
-        Date stopDate = null;
-        DateTime stopDateTime = null, startDateTime = null;
+        DateTime stopDateTime, startDateTime;
         RegimenType regimenType = null;
         PatientIdentifier pepfarIdentifier = patient.getPatientIdentifier(Utils.PEPFAR_IDENTIFIER_INDEX);
-        String pepfarID = "";
-        String ndrCode = "";
-        Obs obs = null;
-        int valueCoded = 0, durationInDays = 0;
-        CodedSimpleType codedSimpleType = null;
+        String ndrCode;
+        Obs obs;
+        int valueCoded, durationInDays;
+        CodedSimpleType codedSimpleType;
         if (!obsListForAVisit.isEmpty() && pepfarIdentifier != null && Utils.contains(obsListForAVisit, Utils.CURRENT_REGIMEN_LINE_CONCEPT)) {
-            pepfarID = pepfarIdentifier.getIdentifier();
+            String pepfarID = pepfarIdentifier.getIdentifier();
 
-            visitID = Utils.getVisitId(pepfarID, visitDate);
+            String visitID = Utils.getVisitId(pepfarID, visitDate);
 
             regimenType = new RegimenType();
             regimenType.setVisitID(visitID);
@@ -385,7 +374,7 @@ public class PharmacyDictionary {
                 if (stopDateTime != null) {
                     durationInDays = Utils.getDateDiffInDays(startDateTime.toDate(), stopDateTime.toDate());
                     regimenType.setPrescribedRegimenDuration(String.valueOf(durationInDays));//PrescribedRegimenDuration
-                    stopDate = stopDateTime.toDate();
+                   Date stopDate = stopDateTime.toDate();
                     /*
                          -DateRegimenEnded
                          -DateRegimenEndedDD
@@ -439,8 +428,8 @@ public class PharmacyDictionary {
     }
 
     public Boolean retrieveSubstitutionIndicator(List<Obs> obsList) {
-        Obs obs = null;
-        int valueCoded = 0;
+        Obs obs;
+        int valueCoded;
         Boolean ans = Boolean.FALSE;
         obs = Utils.extractObs(Utils.REGIMEN_MEDICATION_PLAN, obsList);
         if (obs != null) {
@@ -461,8 +450,8 @@ public class PharmacyDictionary {
     }
 
     public Boolean retrieveSwitchIndicator(List<Obs> obsList) {
-        Obs obs = null;
-        int valueCoded = 0;
+        Obs obs;
+        int valueCoded;
         Boolean ans = Boolean.FALSE;
         obs = Utils.extractObs(Utils.REGIMEN_MEDICATION_PLAN, obsList);
         if (obs != null) {
@@ -484,14 +473,13 @@ public class PharmacyDictionary {
 
     public DateTime retrieveMedicationDuration(Date visitDate, List<Obs> obsList) {
         DateTime stopDateTime = null;
-        DateTime startDateTime = null;
-        int durationDays = 0;
-        Obs obs = null;
-        List<Obs> targetObsList=new ArrayList<Obs>();
-        
+        DateTime startDateTime;
+        int durationDays;
+        Obs obs;
+
         Obs obsGroup = Utils.extractObs(Utils.ARV_DRUGS_GROUPING_CONCEPT_SET, obsList);
         if (obsGroup != null) {
-            targetObsList.addAll(obsGroup.getGroupMembers());
+            List<Obs> targetObsList = new ArrayList<>(obsGroup.getGroupMembers());
             obs = Utils.extractObs(Utils.MEDICATION_DURATION_CONCEPT, targetObsList);
             if (obs != null) {
                 durationDays = (int) obs.getValueNumeric().doubleValue();
@@ -621,7 +609,7 @@ public class PharmacyDictionary {
             throw new DatatypeConfigurationException(Arrays.toString(ex.getStackTrace()));
         }
     }
-   
+
     private RegimenType createOIType(Patient pts, Encounter enc, List<Obs> OIDrugObsList)
             throws DatatypeConfigurationException {
         try {

--- a/omod/src/main/java/org/openmrs/module/nigeriaemr/nigeriaQualFactory/NigQualUtil.java
+++ b/omod/src/main/java/org/openmrs/module/nigeriaemr/nigeriaQualFactory/NigQualUtil.java
@@ -50,26 +50,6 @@ public class NigQualUtil {
 		return patients;
 	}
 	
-	private static Marshaller createMarshaller(JAXBContext jaxbContext, String xsd) throws JAXBException, SAXException {
-		Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
-		
-		SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-		
-		java.net.URL xsdFilePath = Thread.currentThread().getContextClassLoader().getResource(xsd);
-		assert xsdFilePath != null;
-		
-		Schema schema = sf.newSchema(xsdFilePath);
-		
-		jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-		jaxbMarshaller.setProperty(Marshaller.JAXB_ENCODING, "UTF-8");
-		
-		jaxbMarshaller.setSchema(schema);
-		
-		//Call Validator class to perform the validation
-		jaxbMarshaller.setEventHandler(new Validator());
-		return jaxbMarshaller;
-	}
-	
 	public static void createXMLFile(Object data, String xmlFile, String xsdContextPath, String xsdFileName)
 	        throws IOException, SAXException, JAXBException {
 		
@@ -85,7 +65,7 @@ public class NigQualUtil {
 		CustomErrorHandler errorHandler = new CustomErrorHandler();
 		JAXBContext jaxbContext = JAXBContext.newInstance(xsdContextPath);
 		
-		Marshaller jaxbMarshaller = createMarshaller(jaxbContext, xsdFileName);
+		Marshaller jaxbMarshaller = Utils.createMarshaller(jaxbContext, xsdFileName);
 		
 		javax.xml.validation.Validator validator = jaxbMarshaller.getSchema().newValidator();
 		jaxbMarshaller.marshal(data, aXMLFile);


### PR DESCRIPTION
The ndr generator throws out of memory when running on database of >10k patients.
This module fixes some of the issue identified
a. Using singleton object for DatatypeFactory in Utils class and JaxbMarshaller object
b. Retrieve only patient ids for patient instead of actual patient object to reduce amount of object kept 
    in memory
c. Close all SQL connections