### PR TITLE
default to global property if stateCode and lgaCode is not in DB

### DIFF
--- a/omod/src/main/java/org/openmrs/module/nigeriaemr/fragment/controller/NdrFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/nigeriaemr/fragment/controller/NdrFragmentController.java
@@ -136,7 +136,8 @@ public class NdrFragmentController {
 			IPReportingState = datimMap.get().getStateCode().toString();
 			IPReportingLgaCode = datimMap.get().getLgaCode().toString();
 		} else {
-			throw new Exception("Invalid datimCode configured");
+			IPReportingState = Utils.getIPReportingState();
+			IPReportingLgaCode = Utils.getIPReportingLgaCode();
 		}
 		
 		//Create an xml file and save in today's folder

--- a/omod/src/main/java/org/openmrs/module/nigeriaemr/ndrUtils/Utils.java
+++ b/omod/src/main/java/org/openmrs/module/nigeriaemr/ndrUtils/Utils.java
@@ -397,14 +397,22 @@ public class Utils {
 		NigeriaemrService nigeriaemrService = Context.getService(NigeriaemrService.class);
 		String datimCode = Context.getAdministrationService().getGlobalProperty("facility_datim_code");
 		Optional<DatimMap> datimMap = Optional.ofNullable(nigeriaemrService.getDatatimMapByDataimId(datimCode));
-		return datimMap.map(map -> map.getStateCode().toString()).orElse(null);
+		if (datimMap.isPresent()) {
+			return datimMap.map(map -> map.getStateCode().toString()).orElse(null);
+		}else{
+			return Context.getAdministrationService().getGlobalProperty("partner_reporting_state");
+		}
 	}
 	
 	public static String getIPReportingLgaCode() {
 		NigeriaemrService nigeriaemrService = Context.getService(NigeriaemrService.class);
 		String datimCode = Context.getAdministrationService().getGlobalProperty("facility_datim_code");
 		Optional<DatimMap> datimMap = Optional.ofNullable(nigeriaemrService.getDatatimMapByDataimId(datimCode));
-		return datimMap.map(map -> map.getLgaCode().toString()).orElse(null);
+		if (datimMap.isPresent()) {
+			return datimMap.map(map -> map.getLgaCode().toString()).orElse(null);
+		}else{
+			return Context.getAdministrationService().getGlobalProperty("partner_reporting_lga_code");
+		}
 	}
 	
 	//date is always saved as yyyy-MM-dd


### PR DESCRIPTION
if state code and lga code is not in db, it should default to global property configuration

this change came as a result of new facilities who were just getting their  datim codes 